### PR TITLE
FIX: dev profile don't support debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
 ]
 
 [profile.dev]
-debug = 0
 
 [profile.release]
 panic = 'unwind'


### PR DESCRIPTION
Currently, we can't debug parami-blockchain's binary. After a lot of investigation, we find its root cause:

In root cargo.toml, we define debug = 0, so the binary built didn't carry any debug information.

Solution is simple, just remove this argument in dev profile.

Thanks for ruibin's sharp intuition.


**Type of change**

<!-- Please delete options that are not relevant. -->
<!-- Any change requires storage migration should be marked as Breaking Change -->

* [x] Bug Fix (non-breaking change which fixes an issue)

**Checklist**

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] New and existing benchmarks pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
* [x] I have checked my code and corrected any misspellings
