### PR TITLE
add force transfer did interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "parami-did-utils",
+ "parami-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/pallets/ad/src/mock.rs
+++ b/pallets/ad/src/mock.rs
@@ -164,6 +164,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = Nft;
 }
 
 parameter_types! {

--- a/pallets/advertiser/src/mock.rs
+++ b/pallets/advertiser/src/mock.rs
@@ -82,6 +82,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = sp_core::H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = ();
 }
 
 parameter_types! {

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -25,6 +25,7 @@ version = '1.0'
 
 [dependencies]
 parami-did-utils = { path = 'utils', default-features = false }
+parami-traits = { path = '../traits', default-features = false }
 
 serde = { version = '1.0', optional = true }
 

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
         }
 
         #[pallet::weight(T::WeightInfo::transfer())]
-        pub fn force_transfer(
+        pub fn force_transfer_with_assets(
             origin: OriginFor<T>,
             did: T::DecentralizedId,
             dest: AccountOf<T>,
@@ -181,7 +181,7 @@ pub mod pallet {
 
             let ad3_balance = T::Currency::total_balance(&source);
             T::Currency::transfer(&source, &dest, ad3_balance, AllowDeath)?;
-            T::Nfts::force_transfer_all_assets(&source, &dest)?;
+            T::Nfts::force_transfer_all_fractions(&source, &dest)?;
 
             <Metadata<T>>::insert(did, meta);
             <DidOf<T>>::remove(&source);

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -20,10 +20,13 @@ mod types;
 use frame_support::{
     dispatch::DispatchResult,
     ensure,
-    traits::{EnsureOrigin, NamedReservableCurrency, StorageVersion},
+    traits::{
+        Currency, EnsureOrigin, ExistenceRequirement::AllowDeath, NamedReservableCurrency,
+        StorageVersion,
+    },
 };
 use parami_did_utils::derive_storage_key;
-use scale_info::TypeInfo;
+use parami_traits::Nfts;
 use sp_runtime::{
     traits::{
         Hash, LookupError, MaybeDisplay, MaybeMallocSizeOf, MaybeSerializeDeserialize, Member,
@@ -80,6 +83,8 @@ pub mod pallet {
 
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+
+        type Nfts: Nfts<AccountOf<Self>>;
     }
 
     #[pallet::pallet]
@@ -155,6 +160,34 @@ pub mod pallet {
             let did = <DidOf<T>>::get(&who).ok_or(Error::<T>::DidNotExists)?;
 
             Self::assign(&did, &account)?;
+
+            Ok(())
+        }
+
+        #[pallet::weight(T::WeightInfo::transfer())]
+        pub fn force_transfer(
+            origin: OriginFor<T>,
+            did: T::DecentralizedId,
+            dest: AccountOf<T>,
+        ) -> DispatchResult {
+            let _who = ensure_root(origin)?;
+
+            ensure!(!<DidOf<T>>::contains_key(&dest), Error::<T>::DidExists);
+            let mut meta = <Metadata<T>>::get(did).ok_or(Error::<T>::DidNotExists)?;
+
+            let source = meta.account.clone();
+            meta.account = dest.clone();
+            meta.created = <frame_system::Pallet<T>>::block_number();
+
+            let ad3_balance = T::Currency::total_balance(&source);
+            T::Currency::transfer(&source, &dest, ad3_balance, AllowDeath)?;
+            T::Nfts::force_transfer_all_assets(&source, &dest)?;
+
+            <Metadata<T>>::insert(did, meta);
+            <DidOf<T>>::remove(&source);
+            <DidOf<T>>::insert(dest.clone(), did);
+
+            Self::deposit_event(Event::<T>::Transferred(did.clone(), source, dest.clone()));
 
             Ok(())
         }

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -86,6 +86,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = sp_core::H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -1,10 +1,11 @@
 use crate::{mock::*, DidOf, EnsureDid, Error, Metadata, ReferrerOf};
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::Currency};
 use parami_did_utils::derive_storage_key;
 use sp_core::offchain::{
     testing::{TestOffchainExt, TestPersistentOffchainDB},
     OffchainDbExt,
 };
+use sp_runtime::DispatchError;
 
 #[test]
 fn should_register() {
@@ -180,5 +181,61 @@ fn should_ensure() {
         assert_eq!(ensure.unwrap(), (DID_ALICE, ALICE));
 
         assert!(EnsureDid::<Test>::try_origin(Origin::signed(BOB)).is_err());
+    });
+}
+
+#[test]
+fn should_force_transfer_did() {
+    new_test_ext().execute_with(|| {
+        // Alice has DID, Bob has no DID
+
+        assert_eq!(
+            <Test as crate::Config>::Currency::total_balance(&ALICE),
+            100u128
+        );
+        assert_eq!(
+            <Test as crate::Config>::Currency::total_balance(&BOB),
+            100u128
+        );
+        assert_eq!(Did::did_of(ALICE).unwrap(), DID_ALICE);
+        assert_eq!(Did::did_of(BOB), None);
+
+        assert_ok!(Did::force_transfer(Origin::root(), DID_ALICE, BOB));
+
+        assert_eq!(<Test as crate::Config>::Currency::total_balance(&ALICE), 0);
+        assert_eq!(<Test as crate::Config>::Currency::total_balance(&BOB), 200);
+        assert_eq!(Did::did_of(BOB).unwrap(), DID_ALICE);
+        assert_eq!(Did::did_of(ALICE), None);
+    });
+}
+
+#[test]
+fn should_fail_force_transfer_did_if_not_root_user() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            Did::force_transfer(Origin::signed(ALICE), DID_ALICE, BOB),
+            DispatchError::BadOrigin
+        );
+    });
+}
+
+#[test]
+fn should_fail_force_transfer_did_if_did_not_exist() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            Did::force_transfer(Origin::root(), DID_BOB, BOB),
+            Error::<Test>::DidNotExists,
+        );
+    });
+}
+
+#[test]
+fn should_fail_force_transfer_did_if_dest_bind_did() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Did::register(Origin::signed(BOB), None));
+        assert_noop!(
+            Did::force_transfer(Origin::root(), DID_ALICE, BOB),
+            Error::<Test>::DidExists,
+        );
     });
 }

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -200,7 +200,11 @@ fn should_force_transfer_did() {
         assert_eq!(Did::did_of(ALICE).unwrap(), DID_ALICE);
         assert_eq!(Did::did_of(BOB), None);
 
-        assert_ok!(Did::force_transfer(Origin::root(), DID_ALICE, BOB));
+        assert_ok!(Did::force_transfer_with_assets(
+            Origin::root(),
+            DID_ALICE,
+            BOB
+        ));
 
         assert_eq!(<Test as crate::Config>::Currency::total_balance(&ALICE), 0);
         assert_eq!(<Test as crate::Config>::Currency::total_balance(&BOB), 200);
@@ -213,7 +217,7 @@ fn should_force_transfer_did() {
 fn should_fail_force_transfer_did_if_not_root_user() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Did::force_transfer(Origin::signed(ALICE), DID_ALICE, BOB),
+            Did::force_transfer_with_assets(Origin::signed(ALICE), DID_ALICE, BOB),
             DispatchError::BadOrigin
         );
     });
@@ -223,7 +227,7 @@ fn should_fail_force_transfer_did_if_not_root_user() {
 fn should_fail_force_transfer_did_if_did_not_exist() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Did::force_transfer(Origin::root(), DID_BOB, BOB),
+            Did::force_transfer_with_assets(Origin::root(), DID_BOB, BOB),
             Error::<Test>::DidNotExists,
         );
     });
@@ -234,7 +238,7 @@ fn should_fail_force_transfer_did_if_dest_bind_did() {
     new_test_ext().execute_with(|| {
         assert_ok!(Did::register(Origin::signed(BOB), None));
         assert_noop!(
-            Did::force_transfer(Origin::root(), DID_ALICE, BOB),
+            Did::force_transfer_with_assets(Origin::root(), DID_ALICE, BOB),
             Error::<Test>::DidExists,
         );
     });

--- a/pallets/linker/src/mock.rs
+++ b/pallets/linker/src/mock.rs
@@ -110,6 +110,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = ();
 }
 
 impl parami_ocw::Config for Test {}

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -25,8 +25,8 @@ use frame_support::{
     traits::{
         tokens::{
             fungibles::{
-                metadata::Mutate as FungMetaMutate, Create as FungCreate, Mutate as FungMutate,
-                Transfer as FungTransfer,
+                metadata::Mutate as FungMetaMutate, Create as FungCreate, Inspect,
+                Mutate as FungMutate, Transfer as FungTransfer,
             },
             nonfungibles::{Create as NftCreate, Mutate as NftMutate},
         },
@@ -40,7 +40,7 @@ use frame_system::offchain::SendTransactionTypes;
 use parami_did::EnsureDid;
 use parami_traits::{
     types::{Network, Task},
-    Links, Swaps,
+    Links, Nfts, Swaps,
 };
 use sp_core::U512;
 use sp_runtime::{
@@ -680,5 +680,19 @@ impl<T: Config> Pallet<T> {
         let value: D = value.try_into().map_err(|_| Error::<T>::Overflow)?;
 
         Ok(value)
+    }
+}
+
+impl<T: Config> Nfts<T::AccountId> for Pallet<T> {
+    fn force_transfer_all_assets(
+        src: &T::AccountId,
+        dest: &T::AccountId,
+    ) -> Result<(), DispatchError> {
+        for (_nft_id, nft_meta) in <Metadata<T>>::iter() {
+            let balance = T::Assets::balance(nft_meta.token_asset_id, &src);
+            T::Assets::transfer(nft_meta.token_asset_id, src, dest, balance, false)?;
+        }
+
+        Ok(())
     }
 }

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -684,7 +684,7 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> Nfts<T::AccountId> for Pallet<T> {
-    fn force_transfer_all_assets(
+    fn force_transfer_all_fractions(
         src: &T::AccountId,
         dest: &T::AccountId,
     ) -> Result<(), DispatchError> {

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -163,6 +163,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = Nft;
 }
 
 impl parami_ocw::Config for Test {}

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -569,7 +569,7 @@ fn should_transfer_all_assets() {
         assert_eq!(Assets::balance(0, &BOB), 0);
         assert_eq!(Assets::balance(1, &BOB), 0);
 
-        assert_ok!(Nft::force_transfer_all_assets(&ALICE, &BOB));
+        assert_ok!(Nft::force_transfer_all_fractions(&ALICE, &BOB));
 
         assert_eq!(Assets::balance(0, &ALICE), 0);
         assert_eq!(Assets::balance(1, &ALICE), 0);

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{mock::*, Deposit, Deposits, Error, External, Metadata, Ported, Porting, Preferred};
 use codec::Decode;
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::fungibles::Mutate};
 use parami_primitives::constants::DOLLARS;
-use parami_traits::{types::Network, Swaps};
+use parami_traits::{types::Network, Nfts, Swaps};
 use parking_lot::RwLock;
 use sp_core::offchain::{testing, OffchainWorkerExt, TransactionPoolExt};
 use sp_runtime::offchain::testing::PoolState;
@@ -539,5 +539,41 @@ fn should_sumbit_porting() {
 
         let preferred = <Preferred<Test>>::get(DID_BOB).expect("prefered should have data");
         assert_eq!(preferred, 2);
+    });
+}
+
+#[test]
+fn should_transfer_all_assets() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Nft::back(Origin::signed(BOB), 0, 2000 * DOLLARS));
+        assert_ok!(Nft::mint(
+            Origin::signed(ALICE),
+            0,
+            b"Test Token1".to_vec(),
+            b"XTT1".to_vec()
+        ));
+
+        assert_ok!(Nft::back(Origin::signed(BOB), 1, 2000 * DOLLARS));
+        assert_ok!(Nft::mint(
+            Origin::signed(ALICE),
+            1,
+            b"Test Token2".to_vec(),
+            b"XTT2".to_vec()
+        ));
+
+        assert_ok!(Assets::mint_into(0, &ALICE, 500));
+        assert_ok!(Assets::mint_into(1, &ALICE, 1000));
+
+        assert_eq!(Assets::balance(0, &ALICE), 500);
+        assert_eq!(Assets::balance(1, &ALICE), 1000);
+        assert_eq!(Assets::balance(0, &BOB), 0);
+        assert_eq!(Assets::balance(1, &BOB), 0);
+
+        assert_ok!(Nft::force_transfer_all_assets(&ALICE, &BOB));
+
+        assert_eq!(Assets::balance(0, &ALICE), 0);
+        assert_eq!(Assets::balance(1, &ALICE), 0);
+        assert_eq!(Assets::balance(0, &BOB), 500);
+        assert_eq!(Assets::balance(1, &BOB), 1000);
     });
 }

--- a/pallets/tag/src/mock.rs
+++ b/pallets/tag/src/mock.rs
@@ -82,6 +82,7 @@ impl parami_did::Config for Test {
     type DecentralizedId = sp_core::H160;
     type Hashing = Keccak256;
     type WeightInfo = ();
+    type Nfts = ();
 }
 
 parameter_types! {

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -9,6 +9,9 @@ pub use swaps::Swaps;
 mod tags;
 pub use tags::Tags;
 
+mod nfts;
+pub use nfts::Nfts;
+
 pub mod types {
     pub use parami_primitives::{Network, Task};
 }

--- a/pallets/traits/src/nfts.rs
+++ b/pallets/traits/src/nfts.rs
@@ -1,0 +1,12 @@
+use sp_runtime::DispatchError;
+
+pub trait Nfts<AccountId> {
+    // force transfer all assets of account src to account dest
+    fn force_transfer_all_assets(src: &AccountId, dest: &AccountId) -> Result<(), DispatchError>;
+}
+
+impl<AccountId> Nfts<AccountId> for () {
+    fn force_transfer_all_assets(_src: &AccountId, _dest: &AccountId) -> Result<(), DispatchError> {
+        Ok(())
+    }
+}

--- a/pallets/traits/src/nfts.rs
+++ b/pallets/traits/src/nfts.rs
@@ -2,11 +2,15 @@ use sp_runtime::DispatchError;
 
 pub trait Nfts<AccountId> {
     // force transfer all assets of account src to account dest
-    fn force_transfer_all_assets(src: &AccountId, dest: &AccountId) -> Result<(), DispatchError>;
+    fn force_transfer_all_fractions(src: &AccountId, dest: &AccountId)
+        -> Result<(), DispatchError>;
 }
 
 impl<AccountId> Nfts<AccountId> for () {
-    fn force_transfer_all_assets(_src: &AccountId, _dest: &AccountId) -> Result<(), DispatchError> {
+    fn force_transfer_all_fractions(
+        _src: &AccountId,
+        _dest: &AccountId,
+    ) -> Result<(), DispatchError> {
         Ok(())
     }
 }

--- a/runtimes/dana/src/lib.rs
+++ b/runtimes/dana/src/lib.rs
@@ -1160,6 +1160,7 @@ impl parami_did::Config for Runtime {
     type DecentralizedId = DecentralizedId;
     type Hashing = Keccak256;
     type WeightInfo = parami_did::weights::SubstrateWeight<Runtime>;
+    type Nfts = Nft;
 }
 
 parameter_types! {

--- a/runtimes/dana/src/lib.rs
+++ b/runtimes/dana/src/lib.rs
@@ -171,7 +171,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("parami"),
     impl_name: create_runtime_str!("parami-node"),
     authoring_version: 20,
-    spec_version: 330,
+    spec_version: 331,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtimes/para/src/lib.rs
+++ b/runtimes/para/src/lib.rs
@@ -211,7 +211,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("parami"),
     impl_name: create_runtime_str!("parami-node"),
     authoring_version: 20,
-    spec_version: 330,
+    spec_version: 331,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtimes/para/src/lib.rs
+++ b/runtimes/para/src/lib.rs
@@ -1367,6 +1367,7 @@ impl parami_did::Config for Runtime {
     type DecentralizedId = DecentralizedId;
     type Hashing = Keccak256;
     type WeightInfo = parami_did::weights::SubstrateWeight<Runtime>;
+    type Nfts = Nft;
 }
 
 parameter_types! {


### PR DESCRIPTION
This pr adds an extrinsic which allows root user forcing transfer did to another account, and transfer all of its assets. It should be used for account recovery only.

**Type of change**

- [x] New Feature (non-breaking change which adds functionality)